### PR TITLE
Added onLoad option which gets called when the idle content loads

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import React from "react";
 import useIdleUntilUrgent from "use-idle-until-urgent";
 
 const Component = props => {
-  const { getNow } = props;
+  const { getNow, onLoad } = props;
   const IdleUntilUrgentlyLoadedComponent = useIdleUntilUrgent(
     async () => {
       const module = await import("./IdleUntilUrgentlyLoadedComponent");
@@ -41,6 +41,7 @@ const Component = props => {
       fallback: () => <div>Loading...</div>, // default null
       getNow, // default false, set this to true on user input to immediately load the component.
       timeoutFallbackMs: 5000 // default 5000 ms
+      onLoad, // default () => {}, this is a function that gets called when the idle content is loaded.
     }
   );
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "React hook that enables easy use of the idle until urgent component loading strategy",
   "main": "dist/use-idle-until-urgent.js",
   "umd:main": "dist/use-idle-until-urgent.umd.js",

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,8 @@ const makeIdleGetter = (workFn, options) => {
 };
 
 const useIdleUntilUrgent = (func, options) => {
-  let { fallback, getNow, timeoutFallbackMs } = options;
+  let { fallback, getNow, onLoad, timeoutFallbackMs } = options;
+  onLoad = typeof onLoad !== "undefined" ? onLoad : () => {};
   fallback = typeof fallback !== "undefined" ? fallback : null;
   getNow = typeof getNow !== "undefined" ? getNow : false;
   timeoutFallbackMs =
@@ -55,6 +56,7 @@ const useIdleUntilUrgent = (func, options) => {
   }
 
   if (!!result) {
+    onLoad();
     return result.payload;
   } else {
     return fallback;


### PR DESCRIPTION
## Description

When using idle-until-urgent strategy, it is often useful to have a way of knowing when the idle content has been loaded. This PR adds an extra `onLoad` option, that expects a function which gets called when the idle content is loaded.